### PR TITLE
Genesis alp

### DIFF
--- a/programs/perpetuals/src/error.rs
+++ b/programs/perpetuals/src/error.rs
@@ -76,4 +76,6 @@ pub enum PerpetualsError {
     UnresolvedStake,
     #[msg("Reached bucket mint limit")]
     BucketMintLimit,
+    #[msg("Genesis ALP add liquidity limit reached")]
+    GenesisAlpLimitReached,
 }

--- a/programs/perpetuals/src/instructions.rs
+++ b/programs/perpetuals/src/instructions.rs
@@ -19,6 +19,7 @@ pub mod test_init;
 
 // public instructions
 pub mod add_collateral;
+pub mod add_genesis_liquidity;
 pub mod add_liquid_stake;
 pub mod add_liquidity;
 pub mod add_locked_stake;
@@ -52,9 +53,10 @@ pub mod update_pool_aum;
 
 // bring everything in scope
 pub use {
-    add_collateral::*, add_custody::*, add_liquid_stake::*, add_liquidity::*, add_locked_stake::*,
-    add_pool::*, add_vest::*, claim_stakes::*, claim_vest::*, close_position::*,
-    finalize_locked_stake::*, get_add_liquidity_amount_and_fee::*, get_assets_under_management::*,
+    add_collateral::*, add_custody::*, add_genesis_liquidity::*, add_liquid_stake::*,
+    add_liquidity::*, add_locked_stake::*, add_pool::*, add_vest::*, claim_stakes::*,
+    claim_vest::*, close_position::*, finalize_locked_stake::*,
+    get_add_liquidity_amount_and_fee::*, get_assets_under_management::*,
     get_entry_price_and_fee::*, get_exit_price_and_fee::*, get_liquidation_price::*,
     get_liquidation_state::*, get_lp_token_price::*, get_oracle_price::*, get_pnl::*,
     get_remove_liquidity_amount_and_fee::*, get_swap_amount_and_fees::*, init::*, init_staking::*,

--- a/programs/perpetuals/src/instructions/add_genesis_liquidity.rs
+++ b/programs/perpetuals/src/instructions/add_genesis_liquidity.rs
@@ -1,0 +1,516 @@
+//! AddGenesisLiquidity instruction handler
+
+use {
+    crate::{
+        adapters::SplGovernanceV3Adapter,
+        error::PerpetualsError,
+        instructions::FinalizeLockedStakeParams,
+        math,
+        state::{
+            cortex::Cortex,
+            custody::{get_custody_mint_from_account_info, Custody},
+            oracle::OraclePrice,
+            perpetuals::Perpetuals,
+            pool::{AumCalcMode, Pool},
+            staking::Staking,
+            user_staking::{
+                LockedStake, LockedStakingOption, UserStaking, USER_STAKING_THREAD_AUTHORITY_SEED,
+            },
+        },
+    },
+    anchor_lang::{prelude::*, InstructionData},
+    anchor_spl::token::{Mint, Token, TokenAccount},
+    solana_program::{instruction::Instruction, program_error::ProgramError},
+    std::str::FromStr,
+};
+
+#[derive(Accounts)]
+#[instruction(params: AddGenesisLiquidityParams)]
+pub struct AddGenesisLiquidity<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    #[account(
+        mut,
+        constraint = funding_account.mint == custody.mint,
+        has_one = owner
+    )]
+    pub funding_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        constraint = lp_token_account.mint == lp_token_mint.key(),
+        has_one = owner
+    )]
+    pub lp_token_account: Box<Account<'info, TokenAccount>>,
+
+    /// CHECK: empty PDA, authority for token accounts
+    #[account(
+        seeds = [b"transfer_authority"],
+        bump = perpetuals.transfer_authority_bump
+    )]
+    pub transfer_authority: AccountInfo<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"user_staking",
+                 owner.key().as_ref(), lp_staking.key().as_ref()],
+        bump = lp_user_staking.bump
+    )]
+    pub lp_user_staking: Box<Account<'info, UserStaking>>,
+
+    #[account(
+        mut,
+        seeds = [b"staking", lp_token_mint.key().as_ref()],
+        bump = lp_staking.bump,
+    )]
+    pub lp_staking: Box<Account<'info, Staking>>,
+
+    #[account(
+        mut,
+        seeds = [b"cortex"],
+        bump = cortex.bump
+    )]
+    pub cortex: Box<Account<'info, Cortex>>,
+
+    #[account(
+        seeds = [b"perpetuals"],
+        bump = perpetuals.perpetuals_bump
+    )]
+    pub perpetuals: Box<Account<'info, Perpetuals>>,
+
+    #[account(
+        mut,
+        seeds = [b"pool",
+                 pool.name.as_bytes()],
+        bump = pool.bump
+    )]
+    pub pool: Box<Account<'info, Pool>>,
+
+    #[account(
+        mut,
+        token::mint = lp_staking.staked_token_mint,
+        token::authority = transfer_authority,
+        seeds = [b"staking_staked_token_vault", lp_staking.key().as_ref()],
+        bump = lp_staking.staked_token_vault_bump,
+    )]
+    pub lp_staking_staked_token_vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        seeds = [b"custody",
+                 pool.key().as_ref(),
+                 custody.mint.as_ref()],
+        bump = custody.bump
+    )]
+    pub custody: Box<Account<'info, Custody>>,
+
+    /// CHECK: oracle account for the receiving token
+    #[account(
+        constraint = custody_oracle_account.key() == custody.oracle.oracle_account
+    )]
+    pub custody_oracle_account: AccountInfo<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"custody_token_account",
+                 pool.key().as_ref(),
+                 custody.mint.as_ref()],
+        bump = custody.token_account_bump
+    )]
+    pub custody_token_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        seeds = [b"lm_token_mint"],
+        bump = cortex.lm_token_bump
+    )]
+    pub lm_token_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        seeds = [b"lp_token_mint",
+                 pool.key().as_ref()],
+        bump = pool.lp_token_bump
+    )]
+    pub lp_token_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        seeds = [b"governance_token_mint"],
+        bump = cortex.governance_token_bump
+    )]
+    pub governance_token_mint: Box<Account<'info, Mint>>,
+
+    /// CHECK: checked by spl governance v3 program
+    /// A realm represent one project (ADRENA, MANGO etc.) within the governance program
+    pub governance_realm: UncheckedAccount<'info>,
+
+    /// CHECK: checked by spl governance v3 program
+    pub governance_realm_config: UncheckedAccount<'info>,
+
+    /// CHECK: checked by spl governance v3 program
+    /// Token account owned by governance program holding user's locked tokens
+    #[account(mut)]
+    pub governance_governing_token_holding: UncheckedAccount<'info>,
+
+    /// CHECK: checked by spl governance v3 program
+    /// Account owned by governance storing user informations
+    #[account(mut)]
+    pub governance_governing_token_owner_record: UncheckedAccount<'info>,
+
+    /// CHECK: checked by clockwork thread program
+    #[account(mut)]
+    pub lp_stake_resolution_thread: UncheckedAccount<'info>,
+
+    /// CHECK: checked by clockwork thread program
+    #[account(mut)]
+    pub stakes_claim_cron_thread: Box<Account<'info, clockwork_sdk::state::Thread>>,
+
+    /// CHECK: empty PDA, authority for threads
+    #[account(
+        seeds = [USER_STAKING_THREAD_AUTHORITY_SEED, lp_user_staking.key().as_ref()],
+        bump = lp_user_staking.thread_authority_bump
+    )]
+    pub lp_user_staking_thread_authority: AccountInfo<'info>,
+
+    clockwork_program: Program<'info, clockwork_sdk::ThreadProgram>,
+    governance_program: Program<'info, SplGovernanceV3Adapter>,
+    system_program: Program<'info, System>,
+    token_program: Program<'info, Token>,
+    perpetuals_program: Program<'info, Perpetuals>,
+    // remaining accounts:
+    //   pool.tokens.len() custody accounts (read-only, unsigned)
+    //   pool.tokens.len() custody oracles (read-only, unsigned)
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct AddGenesisLiquidityParams {
+    pub lp_stake_resolution_thread_id: u64,
+    pub amount_in: u64,
+    pub min_lp_amount_out: u64,
+}
+
+pub fn add_genesis_liquidity(
+    ctx: Context<AddGenesisLiquidity>,
+    params: &AddGenesisLiquidityParams,
+) -> Result<()> {
+    // check permissions
+    msg!("Check permissions");
+    let perpetuals = ctx.accounts.perpetuals.as_mut();
+    let custody = ctx.accounts.custody.as_mut();
+
+    require!(
+        perpetuals.permissions.allow_add_liquidity
+            && custody.permissions.allow_add_liquidity
+            && !custody.is_virtual,
+        PerpetualsError::InstructionNotAllowed
+    );
+
+    // validate inputs
+    msg!("Validate inputs");
+    if params.amount_in == 0 {
+        return Err(ProgramError::InvalidArgument.into());
+    }
+
+    msg!("amount_in: {}", params.amount_in);
+
+    let pool = ctx.accounts.pool.as_mut();
+
+    let curtime = perpetuals.get_time()?;
+
+    let token_price = OraclePrice::new_from_oracle(
+        &ctx.accounts.custody_oracle_account.to_account_info(),
+        &custody.oracle,
+        curtime,
+        false,
+    )?;
+
+    let token_ema_price = OraclePrice::new_from_oracle(
+        &ctx.accounts.custody_oracle_account.to_account_info(),
+        &custody.oracle,
+        curtime,
+        custody.pricing.use_ema,
+    )?;
+
+    let min_price = if token_price < token_ema_price {
+        token_price
+    } else {
+        token_ema_price
+    };
+
+    // transfer tokens
+    msg!("Transfer tokens");
+    perpetuals.transfer_tokens_from_user(
+        ctx.accounts.funding_account.to_account_info(),
+        ctx.accounts.custody_token_account.to_account_info(),
+        ctx.accounts.owner.to_account_info(),
+        ctx.accounts.token_program.to_account_info(),
+        params.amount_in,
+    )?;
+
+    // compute assets under management
+    msg!("Compute assets under management");
+    let pool_amount_usd =
+        pool.get_assets_under_management_usd(AumCalcMode::Max, ctx.remaining_accounts, curtime)?;
+
+    let token_amount_usd = min_price.get_asset_amount_usd(params.amount_in, custody.decimals)?;
+
+    let lp_amount = if pool_amount_usd == 0 {
+        token_amount_usd
+    } else {
+        math::checked_as_u64(math::checked_div(
+            math::checked_mul(
+                token_amount_usd as u128,
+                ctx.accounts.lp_token_mint.supply as u128,
+            )?,
+            pool_amount_usd,
+        )?)?
+    };
+    msg!("LP tokens to mint: {}", lp_amount);
+
+    require!(
+        lp_amount >= params.min_lp_amount_out,
+        PerpetualsError::MaxPriceSlippage
+    );
+
+    {
+        msg!("Update custody stats");
+        custody.volume_stats.add_liquidity_usd =
+            custody.volume_stats.add_liquidity_usd.wrapping_add(
+                token_ema_price.get_asset_amount_usd(params.amount_in, custody.decimals)?,
+            );
+
+        custody.assets.owned = math::checked_add(custody.assets.owned, params.amount_in)?;
+
+        custody.update_borrow_rate(curtime)?;
+    }
+
+    // Check we do not go over Genesis ALP limits (only in prod)
+    {
+        // Addresses
+        //
+        let (usdc, eth, btc, wsol) = {
+            // For tests
+            // assume custodies based on their position in the array because of changing mints
+            // enough to run unit tests
+            if cfg!(feature = "test") {
+                (
+                    get_custody_mint_from_account_info(&ctx.remaining_accounts[0]),
+                    get_custody_mint_from_account_info(&ctx.remaining_accounts[1]),
+                    get_custody_mint_from_account_info(&ctx.remaining_accounts[2]),
+                    get_custody_mint_from_account_info(&ctx.remaining_accounts[3]),
+                )
+            } else {
+                // For prod
+                (
+                    // Wrapped Bitcoin (Sollet)
+                    Pubkey::from_str("9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E").unwrap(),
+                    // Wrapped Ethereum (Sollet)
+                    Pubkey::from_str("2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk").unwrap(),
+                    Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap(),
+                    Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap(),
+                )
+            }
+        };
+
+        // Limits
+        //
+        let btc_usd_limit = 100_000 * 10u64.pow(6);
+        let eth_usd_limit = 100_000 * 10u64.pow(6);
+        let wsol_usd_limit = 100_000 * 10u64.pow(9);
+        let usdc_usd_limit = 100_000 * 10u64.pow(6);
+
+        if !custody.mint.eq(&btc)
+            && !custody.mint.eq(&eth)
+            && !custody.mint.eq(&wsol)
+            && !custody.mint.eq(&usdc)
+        {
+            // Not handled custody
+            return Err(PerpetualsError::InvalidCustodyState.into());
+        }
+
+        if custody.mint.eq(&btc) && custody.volume_stats.add_liquidity_usd > btc_usd_limit {
+            return Err(PerpetualsError::GenesisAlpLimitReached.into());
+        }
+        if custody.mint.eq(&eth) && custody.volume_stats.add_liquidity_usd > eth_usd_limit {
+            return Err(PerpetualsError::GenesisAlpLimitReached.into());
+        }
+        if custody.mint.eq(&wsol) && custody.volume_stats.add_liquidity_usd > wsol_usd_limit {
+            return Err(PerpetualsError::GenesisAlpLimitReached.into());
+        }
+        if custody.mint.eq(&usdc) && custody.volume_stats.add_liquidity_usd > usdc_usd_limit {
+            return Err(PerpetualsError::GenesisAlpLimitReached.into());
+        }
+    }
+
+    let perpetuals = ctx.accounts.perpetuals.as_mut();
+
+    // mint lp tokens to staking vault directly
+    perpetuals.mint_tokens(
+        ctx.accounts.lp_token_mint.to_account_info(),
+        ctx.accounts.lp_staking_staked_token_vault.to_account_info(),
+        ctx.accounts.transfer_authority.to_account_info(),
+        ctx.accounts.token_program.to_account_info(),
+        lp_amount,
+    )?;
+
+    // update pool stats
+    msg!("Update pool stats");
+    custody.exit(&crate::ID)?;
+    pool.aum_usd =
+        pool.get_assets_under_management_usd(AumCalcMode::EMA, ctx.remaining_accounts, curtime)?;
+
+    msg!("pool.aum_usd: {}", pool.aum_usd);
+
+    let lp_user_staking = ctx.accounts.lp_user_staking.as_mut();
+    let cortex = ctx.accounts.cortex.as_mut();
+    let lp_staking = ctx.accounts.lp_staking.as_mut();
+
+    let staking_option = LockedStakingOption {
+        locked_days: 30,
+        reward_multiplier: 1,
+        lm_reward_multiplier: (Perpetuals::BPS_POWER as f64 * 1.5) as u32,
+        vote_multiplier: 1,
+    };
+
+    // Add stake to UserStaking account
+    let (stake_amount_with_reward_multiplier, stake_amount_with_lm_reward_multiplier) = {
+        let stake_amount_with_reward_multiplier = math::checked_as_u64(math::checked_div(
+            math::checked_mul(lp_amount, staking_option.reward_multiplier as u64)? as u128,
+            Perpetuals::BPS_POWER,
+        )?)?;
+
+        let stake_amount_with_lm_reward_multiplier = math::checked_as_u64(math::checked_div(
+            math::checked_mul(lp_amount, staking_option.lm_reward_multiplier as u64)? as u128,
+            Perpetuals::BPS_POWER,
+        )?)?;
+
+        // Add the new locked staking to the list
+        lp_user_staking.locked_stakes.push(LockedStake {
+            amount: lp_amount,
+            stake_time: perpetuals.get_time()?,
+            claim_time: 0,
+
+            // Transform days in seconds here
+            lock_duration: math::checked_mul(staking_option.locked_days as u64, 3_600 * 24)?,
+            reward_multiplier: staking_option.reward_multiplier,
+            lm_reward_multiplier: staking_option.lm_reward_multiplier,
+            vote_multiplier: staking_option.vote_multiplier,
+
+            amount_with_reward_multiplier: stake_amount_with_reward_multiplier,
+            amount_with_lm_reward_multiplier: stake_amount_with_lm_reward_multiplier,
+
+            resolved: false,
+            stake_resolution_thread_id: params.lp_stake_resolution_thread_id,
+        });
+
+        // Adapt the size of the staking account
+        Perpetuals::realloc(
+            ctx.accounts.owner.to_account_info(),
+            lp_user_staking.clone().to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            lp_user_staking.size(),
+            false,
+        )?;
+
+        // Create a clockwork thread to auto-resolve the staking when it ends
+        {
+            clockwork_sdk::cpi::thread_create(
+                CpiContext::new_with_signer(
+                    ctx.accounts.clockwork_program.to_account_info(),
+                    clockwork_sdk::cpi::ThreadCreate {
+                        payer: ctx.accounts.owner.to_account_info(),
+                        system_program: ctx.accounts.system_program.to_account_info(),
+                        thread: ctx.accounts.lp_stake_resolution_thread.to_account_info(),
+                        authority: ctx
+                            .accounts
+                            .lp_user_staking_thread_authority
+                            .to_account_info(),
+                    },
+                    &[&[
+                        USER_STAKING_THREAD_AUTHORITY_SEED,
+                        lp_user_staking.key().as_ref(),
+                        &[lp_user_staking.thread_authority_bump],
+                    ]],
+                ),
+                // Lamports paid to the clockwork worker executing the thread
+                math::checked_add(
+                    UserStaking::AUTOMATION_EXEC_FEE,
+                    // Provide enough for the thread account to be rent exempt
+                    Rent::get()?
+                        .minimum_balance(ctx.accounts.lp_stake_resolution_thread.data_len()),
+                )?,
+                params.lp_stake_resolution_thread_id.try_to_vec().unwrap(),
+                //
+                // Instruction to be executed with the thread
+                vec![Instruction {
+                    program_id: crate::ID,
+                    accounts: crate::cpi::accounts::FinalizeLockedStake {
+                        caller: ctx.accounts.lp_stake_resolution_thread.to_account_info(),
+                        owner: ctx.accounts.owner.to_account_info(),
+                        transfer_authority: ctx.accounts.transfer_authority.to_account_info(),
+                        user_staking: lp_user_staking.to_account_info(),
+                        staking: lp_staking.to_account_info(),
+                        cortex: cortex.to_account_info(),
+                        perpetuals: perpetuals.to_account_info(),
+                        lm_token_mint: ctx.accounts.lm_token_mint.to_account_info(),
+                        governance_token_mint: ctx.accounts.governance_token_mint.to_account_info(),
+                        governance_realm: ctx.accounts.governance_realm.to_account_info(),
+                        governance_realm_config: ctx
+                            .accounts
+                            .governance_realm_config
+                            .to_account_info(),
+                        governance_governing_token_holding: ctx
+                            .accounts
+                            .governance_governing_token_holding
+                            .to_account_info(),
+                        governance_governing_token_owner_record: ctx
+                            .accounts
+                            .governance_governing_token_owner_record
+                            .to_account_info(),
+                        governance_program: ctx.accounts.governance_program.to_account_info(),
+                        perpetuals_program: ctx.accounts.perpetuals_program.to_account_info(),
+                        system_program: ctx.accounts.system_program.to_account_info(),
+                        token_program: ctx.accounts.token_program.to_account_info(),
+                    }
+                    .to_account_metas(Some(true)),
+                    data: crate::instruction::FinalizeLockedStake {
+                        params: FinalizeLockedStakeParams {
+                            thread_id: params.lp_stake_resolution_thread_id,
+                        },
+                    }
+                    .data(),
+                }
+                .into()],
+                //
+                // Trigger configuration
+                clockwork_sdk::state::Trigger::Timestamp {
+                    unix_ts: staking_option.calculate_end_of_staking(perpetuals.get_time()?)?,
+                },
+            )?;
+        }
+
+        (
+            stake_amount_with_reward_multiplier,
+            stake_amount_with_lm_reward_multiplier,
+        )
+    };
+
+    // Adapt staking account to newly staked tokens
+    {
+        lp_staking.next_staking_round.total_stake = math::checked_add(
+            lp_staking.next_staking_round.total_stake,
+            stake_amount_with_reward_multiplier,
+        )?;
+
+        lp_staking.next_staking_round.lm_total_stake = math::checked_add(
+            lp_staking.next_staking_round.lm_total_stake,
+            stake_amount_with_lm_reward_multiplier,
+        )?;
+
+        lp_staking.nb_locked_tokens = math::checked_add(lp_staking.nb_locked_tokens, lp_amount)?;
+    }
+
+    Ok(())
+}

--- a/programs/perpetuals/src/instructions/remove_locked_stake.rs
+++ b/programs/perpetuals/src/instructions/remove_locked_stake.rs
@@ -150,7 +150,7 @@ pub struct RemoveLockedStake<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone)]
 pub struct RemoveLockedStakeParams {
-    pub locked_stake_index: usize,
+    pub locked_stake_index: u64,
 }
 
 // Remove one stake at a time
@@ -205,7 +205,7 @@ pub fn remove_locked_stake(
     let token_amount_to_unstake = {
         let locked_stake = user_staking
             .locked_stakes
-            .get(params.locked_stake_index)
+            .get(params.locked_stake_index as usize)
             .ok_or(PerpetualsError::CannotFoundStake)?;
 
         // Check the stake have ended and have been resolved
@@ -221,7 +221,9 @@ pub fn remove_locked_stake(
         let token_amount_to_unstake = locked_stake.amount;
 
         // Remove the stake from the list
-        user_staking.locked_stakes.remove(params.locked_stake_index);
+        user_staking
+            .locked_stakes
+            .remove(params.locked_stake_index as usize);
 
         token_amount_to_unstake
     };

--- a/programs/perpetuals/src/instructions/update_pool_aum.rs
+++ b/programs/perpetuals/src/instructions/update_pool_aum.rs
@@ -37,9 +37,6 @@ pub fn update_pool_aum(ctx: Context<UpdatePoolAum>) -> Result<u128> {
 
     let curtime: i64 = perpetuals.get_time()?;
 
-    // update pool stats
-    msg!("Update pool asset under management");
-
     msg!("Previous value: {}", pool.aum_usd);
 
     pool.aum_usd =

--- a/programs/perpetuals/src/lib.rs
+++ b/programs/perpetuals/src/lib.rs
@@ -150,6 +150,13 @@ pub mod perpetuals {
         instructions::add_liquidity(ctx, &params)
     }
 
+    pub fn add_genesis_liquidity(
+        ctx: Context<AddGenesisLiquidity>,
+        params: AddGenesisLiquidityParams,
+    ) -> Result<()> {
+        instructions::add_genesis_liquidity(ctx, &params)
+    }
+
     pub fn remove_liquidity(
         ctx: Context<RemoveLiquidity>,
         params: RemoveLiquidityParams,

--- a/programs/perpetuals/src/state/custody.rs
+++ b/programs/perpetuals/src/state/custody.rs
@@ -169,6 +169,16 @@ pub struct Custody {
     pub token_account_bump: u8,
 }
 
+pub fn get_custody_mint_from_account_info(account_info: &AccountInfo<'_>) -> Pubkey {
+    let data_slice = &account_info.data.borrow()[40..72];
+
+    let mut pubkey_bytes = [0u8; 32];
+
+    pubkey_bytes.copy_from_slice(data_slice);
+
+    Pubkey::from(pubkey_bytes)
+}
+
 #[derive(Copy, Clone, PartialEq, AnchorSerialize, AnchorDeserialize, Default, Debug)]
 pub struct DeprecatedPricingParams {
     pub use_ema: bool,

--- a/programs/perpetuals/src/state/perpetuals.rs
+++ b/programs/perpetuals/src/state/perpetuals.rs
@@ -90,13 +90,6 @@ impl Perpetuals {
         true
     }
 
-    // REPLACE WITH warp to slot
-    #[cfg(feature = "test")]
-    pub fn get_time(&self) -> Result<i64> {
-        Ok(self.inception_time)
-    }
-
-    #[cfg(not(feature = "test"))]
     pub fn get_time(&self) -> Result<i64> {
         let time = solana_program::sysvar::clock::Clock::get()?.unix_timestamp;
         if time > 0 {

--- a/programs/perpetuals/tests/native/main.rs
+++ b/programs/perpetuals/tests/native/main.rs
@@ -5,30 +5,31 @@ pub mod utils;
 
 #[tokio::test]
 pub async fn test_integration() {
-    tests_suite::lm_minting::mint_lm_tokens_from_bucket().await;
+    // tests_suite::lm_minting::mint_lm_tokens_from_bucket().await;
 
-    tests_suite::basic_interactions().await;
+    // tests_suite::basic_interactions().await;
 
-    tests_suite::liquidity::fixed_fees().await;
-    tests_suite::liquidity::insuffisient_fund().await;
-    tests_suite::liquidity::min_max_ratio().await;
+    // tests_suite::liquidity::fixed_fees().await;
+    // tests_suite::liquidity::insuffisient_fund().await;
+    // tests_suite::liquidity::min_max_ratio().await;
+    tests_suite::liquidity::genesis().await;
 
-    tests_suite::position::min_max_leverage().await;
-    tests_suite::position::liquidate_position().await;
-    tests_suite::position::max_user_profit().await;
+    // tests_suite::position::min_max_leverage().await;
+    // tests_suite::position::liquidate_position().await;
+    // tests_suite::position::max_user_profit().await;
 
-    tests_suite::staking::staking_rewards_generation().await;
-    tests_suite::staking::liquid_staking().await;
-    tests_suite::staking::locked_staking_30d().await;
-    tests_suite::staking::multiple_stakers_get_correct_rewards().await;
-    tests_suite::staking::liquid_staking_overlap().await;
-    tests_suite::staking::liquid_staking_overlap_remove_less_than_overlap().await;
-    tests_suite::staking::liquid_staking_overlap_remove_same_as_overlap().await;
-    tests_suite::staking::liquid_staking_overlap_remove_more_than_overlap().await;
+    // tests_suite::staking::staking_rewards_generation().await;
+    // tests_suite::staking::liquid_staking().await;
+    // tests_suite::staking::locked_staking_30d().await;
+    // tests_suite::staking::multiple_stakers_get_correct_rewards().await;
+    // tests_suite::staking::liquid_staking_overlap().await;
+    // tests_suite::staking::liquid_staking_overlap_remove_less_than_overlap().await;
+    // tests_suite::staking::liquid_staking_overlap_remove_same_as_overlap().await;
+    // tests_suite::staking::liquid_staking_overlap_remove_more_than_overlap().await;
 
-    // Long tests
-    tests_suite::staking::resolved_round_overflow().await;
-    tests_suite::staking::auto_claim().await;
+    // // Long tests
+    // tests_suite::staking::resolved_round_overflow().await;
+    // tests_suite::staking::auto_claim().await;
 
-    tests_suite::lp_token::lp_token_price().await;
+    // tests_suite::lp_token::lp_token_price().await;
 }

--- a/programs/perpetuals/tests/native/main.rs
+++ b/programs/perpetuals/tests/native/main.rs
@@ -5,31 +5,31 @@ pub mod utils;
 
 #[tokio::test]
 pub async fn test_integration() {
-    // tests_suite::lm_minting::mint_lm_tokens_from_bucket().await;
+    tests_suite::lm_minting::mint_lm_tokens_from_bucket().await;
 
-    // tests_suite::basic_interactions().await;
+    tests_suite::basic_interactions().await;
 
-    // tests_suite::liquidity::fixed_fees().await;
-    // tests_suite::liquidity::insuffisient_fund().await;
-    // tests_suite::liquidity::min_max_ratio().await;
+    tests_suite::liquidity::fixed_fees().await;
+    tests_suite::liquidity::insuffisient_fund().await;
+    tests_suite::liquidity::min_max_ratio().await;
     tests_suite::liquidity::genesis().await;
 
-    // tests_suite::position::min_max_leverage().await;
-    // tests_suite::position::liquidate_position().await;
-    // tests_suite::position::max_user_profit().await;
+    tests_suite::position::min_max_leverage().await;
+    tests_suite::position::liquidate_position().await;
+    tests_suite::position::max_user_profit().await;
 
-    // tests_suite::staking::staking_rewards_generation().await;
-    // tests_suite::staking::liquid_staking().await;
-    // tests_suite::staking::locked_staking_30d().await;
-    // tests_suite::staking::multiple_stakers_get_correct_rewards().await;
-    // tests_suite::staking::liquid_staking_overlap().await;
-    // tests_suite::staking::liquid_staking_overlap_remove_less_than_overlap().await;
-    // tests_suite::staking::liquid_staking_overlap_remove_same_as_overlap().await;
-    // tests_suite::staking::liquid_staking_overlap_remove_more_than_overlap().await;
+    tests_suite::staking::staking_rewards_generation().await;
+    tests_suite::staking::liquid_staking().await;
+    tests_suite::staking::locked_staking_30d().await;
+    tests_suite::staking::multiple_stakers_get_correct_rewards().await;
+    tests_suite::staking::liquid_staking_overlap().await;
+    tests_suite::staking::liquid_staking_overlap_remove_less_than_overlap().await;
+    tests_suite::staking::liquid_staking_overlap_remove_same_as_overlap().await;
+    tests_suite::staking::liquid_staking_overlap_remove_more_than_overlap().await;
 
-    // // Long tests
-    // tests_suite::staking::resolved_round_overflow().await;
-    // tests_suite::staking::auto_claim().await;
+    // Long tests
+    tests_suite::staking::resolved_round_overflow().await;
+    tests_suite::staking::auto_claim().await;
 
-    // tests_suite::lp_token::lp_token_price().await;
+    tests_suite::lp_token::lp_token_price().await;
 }

--- a/programs/perpetuals/tests/native/test_instructions/add_genesis_liquidity.rs
+++ b/programs/perpetuals/tests/native/test_instructions/add_genesis_liquidity.rs
@@ -1,0 +1,173 @@
+use {
+    crate::utils::{self, pda},
+    anchor_lang::{
+        prelude::{AccountMeta, Pubkey},
+        AnchorSerialize, ToAccountMetas,
+    },
+    perpetuals::{
+        adapters::spl_governance_program_adapter,
+        instructions::AddGenesisLiquidityParams,
+        state::{custody::Custody, pool::Pool, user_staking::UserStaking},
+    },
+    solana_program_test::{BanksClientError, ProgramTestContext},
+    solana_sdk::signer::{keypair::Keypair, Signer},
+    tokio::sync::RwLock,
+};
+
+pub async fn add_genesis_liquidity(
+    program_test_ctx: &RwLock<ProgramTestContext>,
+    owner: &Keypair,
+    payer: &Keypair,
+    pool_pda: &Pubkey,
+    custody_token_mint: &Pubkey,
+    governance_realm_pda: &Pubkey,
+    params: AddGenesisLiquidityParams,
+) -> std::result::Result<(), BanksClientError> {
+    // ==== WHEN ==============================================================
+    // Prepare PDA and addresses
+    let transfer_authority_pda = pda::get_transfer_authority_pda().0;
+    let perpetuals_pda = pda::get_perpetuals_pda().0;
+    let custody_pda = pda::get_custody_pda(pool_pda, custody_token_mint).0;
+    let custody_token_account_pda =
+        pda::get_custody_token_account_pda(pool_pda, custody_token_mint).0;
+    let lp_token_mint_pda = pda::get_lp_token_mint_pda(pool_pda).0;
+    let cortex_pda = pda::get_cortex_pda().0;
+    let lm_token_mint_pda = pda::get_lm_token_mint_pda().0;
+    let lp_staking_pda = pda::get_staking_pda(&lp_token_mint_pda).0;
+    let lp_user_staking_pda = pda::get_user_staking_pda(&owner.pubkey(), &lp_staking_pda).0;
+    let lp_staking_staked_token_vault_pda =
+        pda::get_staking_staked_token_vault_pda(&lp_staking_pda).0;
+    let governance_token_mint_pda = pda::get_governance_token_mint_pda().0;
+
+    let governance_governing_token_holding_pda = pda::get_governance_governing_token_holding_pda(
+        governance_realm_pda,
+        &governance_token_mint_pda,
+    );
+
+    let governance_realm_config_pda = pda::get_governance_realm_config_pda(governance_realm_pda);
+
+    let governance_governing_token_owner_record_pda =
+        pda::get_governance_governing_token_owner_record_pda(
+            governance_realm_pda,
+            &governance_token_mint_pda,
+            &owner.pubkey(),
+        );
+
+    let lp_user_staking_thread_authority_pda =
+        pda::get_user_staking_thread_authority(&lp_user_staking_pda).0;
+    let locked_stake_resolution_thread_address = pda::get_thread_address(
+        &lp_user_staking_thread_authority_pda,
+        params.lp_stake_resolution_thread_id.try_to_vec().unwrap(),
+    );
+
+    let funding_account_address =
+        utils::find_associated_token_account(&owner.pubkey(), custody_token_mint).0;
+    let lp_token_account_address =
+        utils::find_associated_token_account(&owner.pubkey(), &lp_token_mint_pda).0;
+
+    let custody_account = utils::get_account::<Custody>(program_test_ctx, custody_pda).await;
+    let custody_oracle_account_address = custody_account.oracle.oracle_account;
+
+    // Save account state before tx execution
+    let lp_user_staking_account_before =
+        utils::get_account::<UserStaking>(program_test_ctx, lp_user_staking_pda).await;
+
+    let lp_stakes_claim_cron_thread_address = pda::get_thread_address(
+        &lp_user_staking_thread_authority_pda,
+        lp_user_staking_account_before
+            .stakes_claim_cron_thread_id
+            .try_to_vec()
+            .unwrap(),
+    );
+
+    let owner_funding_account_before =
+        utils::get_token_account(program_test_ctx, funding_account_address).await;
+    let owner_lp_token_account_before =
+        utils::get_token_account(program_test_ctx, lp_token_account_address).await;
+    let custody_token_account_before =
+        utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
+
+    let accounts_meta = {
+        let accounts = perpetuals::accounts::AddGenesisLiquidity {
+            owner: owner.pubkey(),
+            funding_account: funding_account_address,
+            lp_token_account: lp_token_account_address,
+            transfer_authority: transfer_authority_pda,
+            lp_staking: lp_staking_pda,
+            cortex: cortex_pda,
+            perpetuals: perpetuals_pda,
+            pool: *pool_pda,
+            custody: custody_pda,
+            custody_oracle_account: custody_oracle_account_address,
+            custody_token_account: custody_token_account_pda,
+            lp_token_mint: lp_token_mint_pda,
+            lm_token_mint: lm_token_mint_pda,
+            lp_user_staking: lp_user_staking_pda,
+            lp_staking_staked_token_vault: lp_staking_staked_token_vault_pda,
+            governance_token_mint: governance_token_mint_pda,
+            governance_realm: *governance_realm_pda,
+            governance_realm_config: governance_realm_config_pda,
+            governance_governing_token_holding: governance_governing_token_holding_pda,
+            governance_governing_token_owner_record: governance_governing_token_owner_record_pda,
+            lp_stake_resolution_thread: locked_stake_resolution_thread_address,
+            stakes_claim_cron_thread: lp_stakes_claim_cron_thread_address,
+            lp_user_staking_thread_authority: lp_user_staking_thread_authority_pda,
+            clockwork_program: clockwork_sdk::ID,
+            governance_program: spl_governance_program_adapter::ID,
+            perpetuals_program: perpetuals::ID,
+            system_program: anchor_lang::system_program::ID,
+            token_program: anchor_spl::token::ID,
+        };
+
+        let mut accounts_meta = accounts.to_account_metas(None);
+
+        let pool_account = utils::get_account::<Pool>(program_test_ctx, *pool_pda).await;
+
+        // For each token, add custody account as remaining_account
+        for custody in &pool_account.custodies {
+            accounts_meta.push(AccountMeta {
+                pubkey: *custody,
+                is_signer: false,
+                is_writable: false,
+            });
+        }
+
+        // For each token, add custody oracle account as remaining_account
+        for custody in &pool_account.custodies {
+            let custody_account = utils::get_account::<Custody>(program_test_ctx, *custody).await;
+
+            accounts_meta.push(AccountMeta {
+                pubkey: custody_account.oracle.oracle_account,
+                is_signer: false,
+                is_writable: false,
+            });
+        }
+
+        accounts_meta
+    };
+
+    utils::create_and_execute_perpetuals_ix(
+        program_test_ctx,
+        accounts_meta,
+        perpetuals::instruction::AddGenesisLiquidity { params },
+        Some(&payer.pubkey()),
+        &[owner, payer],
+        None,
+        None,
+    )
+    .await?;
+
+    // ==== THEN ==============================================================
+    let owner_funding_account_after =
+        utils::get_token_account(program_test_ctx, funding_account_address).await;
+    let owner_lp_token_account_after =
+        utils::get_token_account(program_test_ctx, lp_token_account_address).await;
+    let custody_token_account_after =
+        utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
+
+    assert!(owner_funding_account_after.amount < owner_funding_account_before.amount);
+    assert!(owner_lp_token_account_after.amount == owner_lp_token_account_before.amount);
+    assert!(custody_token_account_after.amount > custody_token_account_before.amount);
+
+    Ok(())
+}

--- a/programs/perpetuals/tests/native/test_instructions/mod.rs
+++ b/programs/perpetuals/tests/native/test_instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod add_custody;
+pub mod add_genesis_liquidity;
 pub mod add_liquid_stake;
 pub mod add_liquidity;
 pub mod add_locked_stake;
@@ -24,10 +25,10 @@ pub mod set_custom_oracle_price;
 pub mod swap;
 
 pub use {
-    add_custody::*, add_liquid_stake::*, add_liquidity::*, add_locked_stake::*, add_pool::*,
-    add_vest::*, claim_stakes::*, claim_vest::*, close_position::*, get_lp_token_price::*,
-    get_update_pool_ix::*, init::*, init_staking::*, init_user_staking::*, liquidate::*,
-    mint_lm_tokens_from_bucket::*, open_position::*, remove_liquid_stake::*, remove_liquidity::*,
-    remove_locked_stake::*, resolve_staking_round::*, set_custody_config::*,
-    set_custom_oracle_price::*, swap::*,
+    add_custody::*, add_genesis_liquidity::*, add_liquid_stake::*, add_liquidity::*,
+    add_locked_stake::*, add_pool::*, add_vest::*, claim_stakes::*, claim_vest::*,
+    close_position::*, get_lp_token_price::*, get_update_pool_ix::*, init::*, init_staking::*,
+    init_user_staking::*, liquidate::*, mint_lm_tokens_from_bucket::*, open_position::*,
+    remove_liquid_stake::*, remove_liquidity::*, remove_locked_stake::*, resolve_staking_round::*,
+    set_custody_config::*, set_custom_oracle_price::*, swap::*,
 };

--- a/programs/perpetuals/tests/native/test_instructions/remove_locked_stake.rs
+++ b/programs/perpetuals/tests/native/test_instructions/remove_locked_stake.rs
@@ -133,7 +133,8 @@ pub async fn remove_locked_stake(
         // Can be higher if user claimed lm rewards
         assert!(
             owner_staked_token_account_before
-                + user_staking_account_before.locked_stakes[params.locked_stake_index].amount
+                + user_staking_account_before.locked_stakes[params.locked_stake_index as usize]
+                    .amount
                 <= owner_staked_token_account_after,
         );
     }

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/genesis.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/genesis.rs
@@ -1,0 +1,281 @@
+use {
+    crate::{test_instructions, utils},
+    maplit::hashmap,
+    perpetuals::{instructions::AddGenesisLiquidityParams, state::cortex::Cortex},
+};
+
+const USDC_DECIMALS: u8 = 6;
+const ETH_DECIMALS: u8 = 6;
+const BTC_DECIMALS: u8 = 6;
+const SOL_DECIMALS: u8 = 6;
+
+pub async fn genesis() {
+    let test_setup = utils::TestSetup::new(
+        vec![utils::UserParam {
+            name: "alice",
+            token_balances: hashmap! {
+                "usdc" => utils::scale(200_000, USDC_DECIMALS),
+                "eth" => utils::scale(200, ETH_DECIMALS),
+                "btc" => utils::scale(50, BTC_DECIMALS),
+            },
+        }],
+        vec![
+            utils::MintParam {
+                name: "usdc",
+                decimals: USDC_DECIMALS,
+            },
+            utils::MintParam {
+                name: "eth",
+                decimals: ETH_DECIMALS,
+            },
+            utils::MintParam {
+                name: "btc",
+                decimals: BTC_DECIMALS,
+            },
+            utils::MintParam {
+                name: "sol",
+                decimals: SOL_DECIMALS,
+            },
+        ],
+        vec!["admin_a", "admin_b", "admin_c"],
+        "usdc",
+        "usdc",
+        6,
+        "ADRENA",
+        "main_pool",
+        vec![
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "usdc",
+                    is_stable: true,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(40.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1, USDC_DECIMALS),
+                    initial_conf: utils::scale_f64(0.01, USDC_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(0, USDC_DECIMALS),
+                payer_user_name: "alice",
+            },
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "eth",
+                    is_stable: false,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(15.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1_500, ETH_DECIMALS),
+                    initial_conf: utils::scale(10, ETH_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(0, ETH_DECIMALS),
+                payer_user_name: "alice",
+            },
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "btc",
+                    is_stable: false,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(15.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(30_000, BTC_DECIMALS),
+                    initial_conf: utils::scale(10, BTC_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(0, BTC_DECIMALS),
+                payer_user_name: "alice",
+            },
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "sol",
+                    is_stable: false,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(30.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(25, SOL_DECIMALS),
+                    initial_conf: utils::scale_f64(0.2, SOL_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(0, SOL_DECIMALS),
+                payer_user_name: "alice",
+            },
+        ],
+        utils::scale(100_000, Cortex::LM_DECIMALS),
+        utils::scale(200_000, Cortex::LM_DECIMALS),
+        utils::scale(300_000, Cortex::LM_DECIMALS),
+        utils::scale(500_000, Cortex::LM_DECIMALS),
+    )
+    .await;
+
+    let alice = test_setup.get_user_keypair_by_name("alice");
+
+    let usdc_mint = &test_setup.get_mint_by_name("usdc");
+    let eth_mint = &test_setup.get_mint_by_name("eth");
+    let btc_mint = &test_setup.get_mint_by_name("btc");
+
+    // Init lp staking
+    {
+        let stakes_claim_cron_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        test_instructions::init_user_staking(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.lp_token_mint_pda,
+            perpetuals::instructions::InitUserStakingParams {
+                stakes_claim_cron_thread_id,
+            },
+        )
+        .await
+        .unwrap();
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+    }
+
+    // Add genesis ALP up to $100_000
+    {
+        let mut lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            usdc_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale(99_000, USDC_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .unwrap();
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+
+        lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            eth_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale(66, ETH_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .unwrap();
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+        lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            btc_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale_f64(3.3, BTC_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .unwrap();
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+    }
+
+    // Add genesis ALP for more than $100_000 should fail
+    {
+        let mut lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        assert!(test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            usdc_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale(10_000, USDC_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .is_err());
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+        lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        assert!(test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            eth_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale(1, ETH_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .is_err());
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+        lp_stake_resolution_thread_id =
+            utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await as u64;
+
+        assert!(test_instructions::add_genesis_liquidity(
+            &test_setup.program_test_ctx,
+            alice,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            btc_mint,
+            &test_setup.governance_realm_pda,
+            AddGenesisLiquidityParams {
+                amount_in: utils::scale(1, BTC_DECIMALS),
+                min_lp_amount_out: 1,
+                lp_stake_resolution_thread_id,
+            },
+        )
+        .await
+        .is_err());
+
+        utils::warp_forward(&test_setup.program_test_ctx, 1).await;
+    }
+}

--- a/programs/perpetuals/tests/native/tests_suite/liquidity/mod.rs
+++ b/programs/perpetuals/tests/native/tests_suite/liquidity/mod.rs
@@ -1,5 +1,6 @@
 pub mod fixed_fees;
+pub mod genesis;
 pub mod insuffisient_fund;
 pub mod min_max_ratio;
 
-pub use {fixed_fees::*, insuffisient_fund::*, min_max_ratio::*};
+pub use {fixed_fees::*, genesis::*, insuffisient_fund::*, min_max_ratio::*};

--- a/programs/perpetuals/tests/native/utils/execute_finalize_locked_stake_thread.rs
+++ b/programs/perpetuals/tests/native/utils/execute_finalize_locked_stake_thread.rs
@@ -18,7 +18,7 @@ pub async fn execute_finalize_locked_stake_thread(
     owner: &Keypair,
     payer: &Keypair,
     governance_realm_pda: &Pubkey,
-    locked_stake_index: usize,
+    locked_stake_index: u64,
 ) -> std::result::Result<(), BanksClientError> {
     let transfer_authority_pda = pda::get_transfer_authority_pda().0;
     let lm_token_mint_pda = pda::get_lm_token_mint_pda().0;
@@ -48,7 +48,7 @@ pub async fn execute_finalize_locked_stake_thread(
         utils::get_account::<UserStaking>(program_test_ctx, user_staking_pda).await;
 
     let stake_resolution_thread_id =
-        user_staking_account.locked_stakes[locked_stake_index].stake_resolution_thread_id;
+        user_staking_account.locked_stakes[locked_stake_index as usize].stake_resolution_thread_id;
 
     let stake_resolution_thread_pda = pda::get_clockwork_thread_pda(
         &thread_authority,

--- a/programs/perpetuals/tests/native/utils/utils.rs
+++ b/programs/perpetuals/tests/native/utils/utils.rs
@@ -480,7 +480,7 @@ pub async fn create_and_execute_perpetuals_ix<T: InstructionData, U: Signers>(
 
     let mut instructions: Vec<solana_sdk::instruction::Instruction> = Vec::new();
 
-    instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(800_000u32));
+    instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(900_000u32));
 
     if pre_ix.is_some() {
         instructions.push(pre_ix.unwrap());


### PR DESCRIPTION
- Adds `add_genesis_liquidity` ix that supports adding liquidity without Fees or Ratio check until liquidity reach a certain level. This ix locks tokens for 30 days.
- Hardcoded value for each custody.

On the side:
- Replace `usize` with `u64`
- Increase default computation limit in tests